### PR TITLE
opt-radio などの情報を記載

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,6 +18,26 @@ Casual Optimization は、特定のベンダーに依存しない数理最適化
 
 ## コミュニティへの参加方法
 
+### Slack
+
 日々のコミュニケーションを Slack 上で行っています。公開前のイベント情報や、輪読会・勉強会の募集、数理最適化に関する質問への回答なども行いますので、以下のリンクからご参加ください。
 
 - [Slack招待リンク](https://join.slack.com/t/casual-opt/shared_invite/zt-1a5rslj1j-ypWSqGGVZf~FW8~8PkH5MQ) 
+
+### YouTube
+
+各種イベントを [YouTube チャンネル](https://www.youtube.com/@casualoptimization4412)で配信しています。
+イベントの告知やは [connpass](https://optimization.connpass.com/) で行っています。
+
+#### Optimization Night
+
+ゲストを招待して、数理最適化に関するトークセッションを行うイベントです。
+参加者と登壇者で交流できるよう、質疑応答・議論の時間を一時間近く設けているのが特徴です。
+
+[YouTube 再生リスト](https://www.youtube.com/playlist?list=PLgD9FpwrqdMyZpaxwOufi6CfUJcqK0Zbe)
+
+#### opt-radio
+
+主催者やゲストが数理最適化について話すラジオのような配信です。
+
+[YouTube 再生リスト](https://www.youtube.com/playlist?list=PLgD9FpwrqdMxZviyWDDrKx30VVzpfHMhv)


### PR DESCRIPTION
opt-radio のページを作るという話だったけれど、目立つところに YouTube へのリンクを置いて YouTube チャンネルを栄えさせる方向が今風かなと思い

- トップの「コミュニティへの参加方法」のところに Slack と並列で YouTube の情報を記載
- YouTube 側で opt-radio, Optimization Night の再生リストを作成
- 各イベントの簡単な説明とともに再生リストへのリンクを記載

という形にしてみました。

他に良さそうな方針ないかとか意見頂けると :pray: 